### PR TITLE
Add bastion map screen with claim overlay

### DIFF
--- a/src/main/java/net/jhbach/bastionfall/BastionFall.java
+++ b/src/main/java/net/jhbach/bastionfall/BastionFall.java
@@ -3,6 +3,7 @@ package net.jhbach.bastionfall;
 import com.mojang.logging.LogUtils;
 import net.jhbach.bastionfall.block.ModBlockEntities;
 import net.jhbach.bastionfall.block.ModBlocks;
+import net.jhbach.bastionfall.network.BastionNetwork;
 import net.jhbach.bastionfall.item.ModItems;
 import net.minecraft.client.Minecraft;
 import net.minecraft.server.level.ServerLevel;
@@ -67,6 +68,8 @@ public class BastionFall
         LOGGER.info(Config.magicNumberIntroduction + Config.magicNumber);
 
         Config.items.forEach((item) -> LOGGER.info("ITEM >> {}", item.toString()));
+
+        BastionNetwork.register();
     }
 
     // Add the example block item to the building blocks tab

--- a/src/main/java/net/jhbach/bastionfall/ClaimStorage.java
+++ b/src/main/java/net/jhbach/bastionfall/ClaimStorage.java
@@ -5,17 +5,23 @@ import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.ChunkPos;
+import net.minecraft.core.Direction;
 import net.minecraft.world.level.saveddata.SavedData;
 import org.jetbrains.annotations.VisibleForTesting;
 
+import java.util.ArrayDeque;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 public class ClaimStorage extends SavedData {
-	private static final String DATA_NAME = "bastionfall_claims";
+        private static final String DATA_NAME = "bastionfall_claims";
 
-	private final Map<ChunkPos, UUID> claims = new HashMap<>();
+        private final Map<ChunkPos, UUID> claims = new HashMap<>();
+        private final Map<IslandCacheKey, CachedIsland> islandCache = new HashMap<>();
+        private long revision = 0;
 
 	public static ClaimStorage load(CompoundTag nbt) {
 		ClaimStorage storage = new ClaimStorage();
@@ -44,36 +50,36 @@ public class ClaimStorage extends SavedData {
 		return nbt;
 	}
 
-	public ClaimStorage() { }
+        public ClaimStorage() { }
 
-	public static ClaimStorage get(ServerLevel level) {
-		if(level.dimension() != level.getServer().overworld().dimension()) {
-			throw new IllegalStateException("ClaimStorage only exists in the Overworld");
+        public static ClaimStorage get(ServerLevel level) {
+                if(level.dimension() != level.getServer().overworld().dimension()) {
+                        throw new IllegalStateException("ClaimStorage only exists in the Overworld");
 		}
 		return level.getDataStorage()
 				.computeIfAbsent(ClaimStorage::load, ClaimStorage::new, DATA_NAME);
 	}
 
-	public boolean isChunkClaimed(ChunkPos pos) {
-		return claims.containsKey(pos);
-	}
+        public boolean isChunkClaimed(ChunkPos pos) {
+                return claims.containsKey(pos);
+        }
 
 	public UUID getChunkOwner(ChunkPos chunk) {
 		return claims.get(chunk);
 	}
 
-	public void claimChunk(ChunkPos pos, UUID owner) {
-		if (!claims.containsKey(pos)) {
-			claims.put(pos, owner);
-			setDirty();
-		}
-	}
+        public void claimChunk(ChunkPos pos, UUID owner) {
+                if (!claims.containsKey(pos)) {
+                        claims.put(pos, owner);
+                        markUpdated();
+                }
+        }
 
-	public void unclaimChunk(ChunkPos pos) {
-		if(claims.remove(pos) != null) {
-			setDirty();
-		}
-	}
+        public void unclaimChunk(ChunkPos pos) {
+                if(claims.remove(pos) != null) {
+                        markUpdated();
+                }
+        }
 
 	public void claimChunksAround(ChunkPos pos, UUID owner, int radius) {
 		for (int dx = -radius; dx <= radius; dx++) {
@@ -95,12 +101,71 @@ public class ClaimStorage extends SavedData {
 		}
 	}
 
-	public Map<ChunkPos, UUID> getClaimStorage() {
-		return claims;
-	}
+        public Map<ChunkPos, UUID> getClaimStorage() {
+                return claims;
+        }
 
-	@VisibleForTesting
-	public void resetClaims() {
-		claims.clear();
-	}
+        @VisibleForTesting
+        public void resetClaims() {
+                claims.clear();
+                markUpdated();
+        }
+
+        public IslandSnapshot buildIslandSnapshot(ChunkPos start, int padding) {
+                long currentRevision = revision;
+                IslandCacheKey key = new IslandCacheKey(start, padding);
+                CachedIsland cached = islandCache.get(key);
+                if (cached != null && cached.revision == currentRevision) {
+                        return cached.snapshot;
+                }
+
+                Set<ChunkPos> visited = new HashSet<>();
+                ArrayDeque<ChunkPos> queue = new ArrayDeque<>();
+                queue.add(start);
+                visited.add(start);
+
+                while (!queue.isEmpty()) {
+                        ChunkPos current = queue.poll();
+                        for (Direction dir : Direction.Plane.HORIZONTAL) {
+                                ChunkPos neighbor = new ChunkPos(current.x + dir.getStepX(), current.z + dir.getStepZ());
+                                if (!visited.contains(neighbor) && isChunkClaimed(neighbor)) {
+                                        visited.add(neighbor);
+                                        queue.add(neighbor);
+                                }
+                        }
+                }
+
+                int minX = visited.stream().mapToInt(c -> c.x).min().orElse(start.x) - padding;
+                int maxX = visited.stream().mapToInt(c -> c.x).max().orElse(start.x) + padding;
+                int minZ = visited.stream().mapToInt(c -> c.z).min().orElse(start.z) - padding;
+                int maxZ = visited.stream().mapToInt(c -> c.z).max().orElse(start.z) + padding;
+
+                int sizeX = maxX - minX + 1;
+                int sizeZ = maxZ - minZ + 1;
+                boolean[] claimed = new boolean[sizeX * sizeZ];
+                for (int x = 0; x < sizeX; x++) {
+                        for (int z = 0; z < sizeZ; z++) {
+                                ChunkPos cp = new ChunkPos(minX + x, minZ + z);
+                                if (isChunkClaimed(cp)) {
+                                        claimed[x + z * sizeX] = true;
+                                }
+                        }
+                }
+
+                IslandSnapshot snapshot = new IslandSnapshot(minX, minZ, sizeX, sizeZ, claimed);
+                islandCache.put(key, new CachedIsland(snapshot, currentRevision));
+                return snapshot;
+        }
+
+        private void markUpdated() {
+                revision++;
+                islandCache.clear();
+                setDirty();
+        }
+
+        public record IslandSnapshot(int minX, int minZ, int sizeX, int sizeZ, boolean[] claimed) { }
+
+        private record IslandCacheKey(ChunkPos start, int padding) { }
+
+        private record CachedIsland(IslandSnapshot snapshot, long revision) { }
 }

--- a/src/main/java/net/jhbach/bastionfall/block/BastionBlock.java
+++ b/src/main/java/net/jhbach/bastionfall/block/BastionBlock.java
@@ -4,7 +4,6 @@ import net.jhbach.bastionfall.ClaimStorage;
 import net.jhbach.bastionfall.network.BastionNetwork;
 import net.jhbach.bastionfall.network.OpenBastionScreenPacket;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
@@ -18,11 +17,6 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.network.PacketDistributor;
 
-import java.util.ArrayDeque;
-import java.util.HashSet;
-import java.util.Queue;
-import java.util.Set;
-
 public class BastionBlock extends Block {
 
         public BastionBlock(BlockBehaviour.Properties properties) {
@@ -33,47 +27,12 @@ public class BastionBlock extends Block {
         @SuppressWarnings("resource")
         public InteractionResult use(BlockState state, Level level, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hit) {
                 if (!level.isClientSide && player instanceof ServerPlayer serverPlayer) {
-                        ClaimStorage storage = ClaimStorage.get((ServerLevel) level);
-                        ChunkPos start = new ChunkPos(pos);
-                        Set<ChunkPos> island = new HashSet<>();
-                        Queue<ChunkPos> queue = new ArrayDeque<>();
-                        queue.add(start);
-                        island.add(start);
-                        while (!queue.isEmpty()) {
-                                ChunkPos current = queue.poll();
-                                for (Direction dir : Direction.Plane.HORIZONTAL) {
-                                        ChunkPos neighbor = new ChunkPos(current.x + dir.getStepX(), current.z + dir.getStepZ());
-                                        if (!island.contains(neighbor) && storage.isChunkClaimed(neighbor)) {
-                                                island.add(neighbor);
-                                                queue.add(neighbor);
-                                        }
-                                }
-                        }
-
-                        int minX = island.stream().mapToInt(c -> c.x).min().orElse(start.x);
-                        int maxX = island.stream().mapToInt(c -> c.x).max().orElse(start.x);
-                        int minZ = island.stream().mapToInt(c -> c.z).min().orElse(start.z);
-                        int maxZ = island.stream().mapToInt(c -> c.z).max().orElse(start.z);
-
-                        minX -= 1;
-                        maxX += 1;
-                        minZ -= 1;
-                        maxZ += 1;
-
-                        int sizeX = maxX - minX + 1;
-                        int sizeZ = maxZ - minZ + 1;
-                        boolean[] claimed = new boolean[sizeX * sizeZ];
-                        for (int x = 0; x < sizeX; x++) {
-                                for (int z = 0; z < sizeZ; z++) {
-                                        ChunkPos cp = new ChunkPos(minX + x, minZ + z);
-                                        if (storage.isChunkClaimed(cp)) {
-                                                claimed[x + z * sizeX] = true;
-                                        }
-                                }
-                        }
+                        ClaimStorage.IslandSnapshot snapshot = ClaimStorage.get((ServerLevel) level)
+                                        .buildIslandSnapshot(new ChunkPos(pos), 1);
 
                         BastionNetwork.CHANNEL.send(PacketDistributor.PLAYER.with(() -> serverPlayer),
-                                new OpenBastionScreenPacket(pos, minX, minZ, sizeX, sizeZ, claimed));
+                                new OpenBastionScreenPacket(pos, snapshot.minX(), snapshot.minZ(),
+                                                snapshot.sizeX(), snapshot.sizeZ(), snapshot.claimed()));
                         return InteractionResult.SUCCESS;
                 }
 

--- a/src/main/java/net/jhbach/bastionfall/block/BastionBlock.java
+++ b/src/main/java/net/jhbach/bastionfall/block/BastionBlock.java
@@ -1,11 +1,82 @@
 package net.jhbach.bastionfall.block;
 
+import net.jhbach.bastionfall.ClaimStorage;
+import net.jhbach.bastionfall.network.BastionNetwork;
+import net.jhbach.bastionfall.network.OpenBastionScreenPacket;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraftforge.network.PacketDistributor;
+
+import java.util.ArrayDeque;
+import java.util.HashSet;
+import java.util.Queue;
+import java.util.Set;
 
 public class BastionBlock extends Block {
 
-	public BastionBlock(BlockBehaviour.Properties properties) {
-		super(properties);
-	}
+        public BastionBlock(BlockBehaviour.Properties properties) {
+                super(properties);
+        }
+
+        @Override
+        @SuppressWarnings("resource")
+        public InteractionResult use(BlockState state, Level level, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hit) {
+                if (!level.isClientSide && player instanceof ServerPlayer serverPlayer) {
+                        ClaimStorage storage = ClaimStorage.get((ServerLevel) level);
+                        ChunkPos start = new ChunkPos(pos);
+                        Set<ChunkPos> island = new HashSet<>();
+                        Queue<ChunkPos> queue = new ArrayDeque<>();
+                        queue.add(start);
+                        island.add(start);
+                        while (!queue.isEmpty()) {
+                                ChunkPos current = queue.poll();
+                                for (Direction dir : Direction.Plane.HORIZONTAL) {
+                                        ChunkPos neighbor = new ChunkPos(current.x + dir.getStepX(), current.z + dir.getStepZ());
+                                        if (!island.contains(neighbor) && storage.isChunkClaimed(neighbor)) {
+                                                island.add(neighbor);
+                                                queue.add(neighbor);
+                                        }
+                                }
+                        }
+
+                        int minX = island.stream().mapToInt(c -> c.x).min().orElse(start.x);
+                        int maxX = island.stream().mapToInt(c -> c.x).max().orElse(start.x);
+                        int minZ = island.stream().mapToInt(c -> c.z).min().orElse(start.z);
+                        int maxZ = island.stream().mapToInt(c -> c.z).max().orElse(start.z);
+
+                        minX -= 1;
+                        maxX += 1;
+                        minZ -= 1;
+                        maxZ += 1;
+
+                        int sizeX = maxX - minX + 1;
+                        int sizeZ = maxZ - minZ + 1;
+                        boolean[] claimed = new boolean[sizeX * sizeZ];
+                        for (int x = 0; x < sizeX; x++) {
+                                for (int z = 0; z < sizeZ; z++) {
+                                        ChunkPos cp = new ChunkPos(minX + x, minZ + z);
+                                        if (storage.isChunkClaimed(cp)) {
+                                                claimed[x + z * sizeX] = true;
+                                        }
+                                }
+                        }
+
+                        BastionNetwork.CHANNEL.send(PacketDistributor.PLAYER.with(() -> serverPlayer),
+                                new OpenBastionScreenPacket(pos, minX, minZ, sizeX, sizeZ, claimed));
+                        return InteractionResult.SUCCESS;
+                }
+
+                return InteractionResult.sidedSuccess(level.isClientSide);
+        }
 }

--- a/src/main/java/net/jhbach/bastionfall/client/BastionMapScreen.java
+++ b/src/main/java/net/jhbach/bastionfall/client/BastionMapScreen.java
@@ -1,0 +1,90 @@
+package net.jhbach.bastionfall.client;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.renderer.texture.DynamicTexture;
+import net.minecraft.client.renderer.texture.TextureManager;
+import com.mojang.blaze3d.platform.NativeImage;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.levelgen.Heightmap;
+
+public class BastionMapScreen extends Screen {
+    private final BlockPos bastionPos;
+    private final int minChunkX;
+    private final int minChunkZ;
+    private final int sizeX;
+    private final int sizeZ;
+    private final boolean[] claimed;
+
+    private ResourceLocation mapTexture;
+    private int textureWidth;
+    private int textureHeight;
+
+    public BastionMapScreen(BlockPos pos, int minChunkX, int minChunkZ, int sizeX, int sizeZ, boolean[] claimed) {
+        super(Component.literal("Bastion Map"));
+        this.bastionPos = pos;
+        this.minChunkX = minChunkX;
+        this.minChunkZ = minChunkZ;
+        this.sizeX = sizeX;
+        this.sizeZ = sizeZ;
+        this.claimed = claimed;
+    }
+
+    @Override
+    protected void init() {
+        super.init();
+        generateMapTexture();
+    }
+
+    private void generateMapTexture() {
+        textureWidth = sizeX * 16;
+        textureHeight = sizeZ * 16;
+        TextureManager tm = Minecraft.getInstance().getTextureManager();
+        DynamicTexture dyn = new DynamicTexture(textureWidth, textureHeight, true);
+        NativeImage img = dyn.getPixels();
+        Level level = Minecraft.getInstance().level;
+        if (level == null) return;
+        int worldXStart = minChunkX * 16;
+        int worldZStart = minChunkZ * 16;
+        for (int dx = 0; dx < textureWidth; dx++) {
+            for (int dz = 0; dz < textureHeight; dz++) {
+                int worldX = worldXStart + dx;
+                int worldZ = worldZStart + dz;
+                BlockPos topPos = level.getHeightmapPos(Heightmap.Types.WORLD_SURFACE, new BlockPos(worldX, 0, worldZ)).below();
+                BlockState state = level.getBlockState(topPos);
+                int color = state.getMapColor(level, topPos).col | 0xFF000000;
+                img.setPixelRGBA(dx, dz, color);
+            }
+        }
+        dyn.upload();
+        mapTexture = tm.register("bastion_map_" + bastionPos.asLong(), dyn);
+    }
+
+    @Override
+    public void render(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
+        this.renderBackground(guiGraphics);
+        if (mapTexture != null) {
+            int x = (this.width - textureWidth) / 2;
+            int y = (this.height - textureHeight) / 2;
+            guiGraphics.blit(mapTexture, x, y, 0, 0, textureWidth, textureHeight, textureWidth, textureHeight);
+            for (int cx = 0; cx < sizeX; cx++) {
+                for (int cz = 0; cz < sizeZ; cz++) {
+                    int index = cx + cz * sizeX;
+                    int col = claimed[index] ? 0x4000FF00 : 0x40FF0000;
+                    guiGraphics.fill(x + cx * 16, y + cz * 16, x + (cx + 1) * 16, y + (cz + 1) * 16, col);
+                }
+            }
+        }
+        super.render(guiGraphics, mouseX, mouseY, partialTick);
+    }
+
+    @Override
+    public boolean isPauseScreen() {
+        return false;
+    }
+}

--- a/src/main/java/net/jhbach/bastionfall/network/BastionNetwork.java
+++ b/src/main/java/net/jhbach/bastionfall/network/BastionNetwork.java
@@ -1,0 +1,26 @@
+package net.jhbach.bastionfall.network;
+
+import net.jhbach.bastionfall.BastionFall;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.network.NetworkRegistry;
+import net.minecraftforge.network.simple.SimpleChannel;
+
+public class BastionNetwork {
+    private static final String PROTOCOL_VERSION = "1";
+
+    public static final SimpleChannel CHANNEL = NetworkRegistry.newSimpleChannel(
+            new ResourceLocation(BastionFall.MODID, "main"),
+            () -> PROTOCOL_VERSION,
+            PROTOCOL_VERSION::equals,
+            PROTOCOL_VERSION::equals
+    );
+
+    private static int nextId = 0;
+
+    public static void register() {
+        CHANNEL.registerMessage(nextId++, OpenBastionScreenPacket.class,
+                OpenBastionScreenPacket::encode,
+                OpenBastionScreenPacket::decode,
+                OpenBastionScreenPacket::handle);
+    }
+}

--- a/src/main/java/net/jhbach/bastionfall/network/OpenBastionScreenPacket.java
+++ b/src/main/java/net/jhbach/bastionfall/network/OpenBastionScreenPacket.java
@@ -1,0 +1,62 @@
+package net.jhbach.bastionfall.network;
+
+import net.jhbach.bastionfall.client.BastionMapScreen;
+import net.minecraft.client.Minecraft;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraftforge.network.NetworkEvent;
+
+import java.util.function.Supplier;
+
+public class OpenBastionScreenPacket {
+    private final BlockPos bastionPos;
+    private final int minChunkX;
+    private final int minChunkZ;
+    private final int sizeX;
+    private final int sizeZ;
+    private final boolean[] claimed;
+
+    public OpenBastionScreenPacket(BlockPos bastionPos, int minChunkX, int minChunkZ, int sizeX, int sizeZ, boolean[] claimed) {
+        this.bastionPos = bastionPos;
+        this.minChunkX = minChunkX;
+        this.minChunkZ = minChunkZ;
+        this.sizeX = sizeX;
+        this.sizeZ = sizeZ;
+        this.claimed = claimed;
+    }
+
+    public static void encode(OpenBastionScreenPacket pkt, FriendlyByteBuf buf) {
+        buf.writeBlockPos(pkt.bastionPos);
+        buf.writeInt(pkt.minChunkX);
+        buf.writeInt(pkt.minChunkZ);
+        buf.writeInt(pkt.sizeX);
+        buf.writeInt(pkt.sizeZ);
+        buf.writeVarInt(pkt.claimed.length);
+        for (boolean b : pkt.claimed) {
+            buf.writeBoolean(b);
+        }
+    }
+
+    public static OpenBastionScreenPacket decode(FriendlyByteBuf buf) {
+        BlockPos pos = buf.readBlockPos();
+        int minX = buf.readInt();
+        int minZ = buf.readInt();
+        int sizeX = buf.readInt();
+        int sizeZ = buf.readInt();
+        int len = buf.readVarInt();
+        boolean[] claimed = new boolean[len];
+        for (int i = 0; i < len; i++) {
+            claimed[i] = buf.readBoolean();
+        }
+        return new OpenBastionScreenPacket(pos, minX, minZ, sizeX, sizeZ, claimed);
+    }
+
+    public static void handle(OpenBastionScreenPacket pkt, Supplier<NetworkEvent.Context> ctx) {
+        ctx.get().enqueueWork(() -> {
+            Minecraft mc = Minecraft.getInstance();
+            if (mc.player == null) return;
+            mc.setScreen(new BastionMapScreen(pkt.bastionPos, pkt.minChunkX, pkt.minChunkZ, pkt.sizeX, pkt.sizeZ, pkt.claimed));
+        });
+        ctx.get().setPacketHandled(true);
+    }
+}


### PR DESCRIPTION
## Summary
- Allow bastion blocks to open a map GUI when used
- Render surrounding chunks with claimed areas highlighted
- Introduce simple network channel to send map data to clients

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68ba236197808327aa944c32e641e68c